### PR TITLE
feat: add compability with kirby-builder plugin

### DIFF
--- a/assets/js/gallery.js
+++ b/assets/js/gallery.js
@@ -5,31 +5,31 @@
     var element   = $(el)
     var api       = element.data('api');
     var mainForm  = element.closest('form.form');
-    var keepUrl   = mainForm.data('keep')
+    var keepUrl   = mainForm.data('keep');
     var offsetFix = true;
 
     element.on('click', '.galleryField__removeBtn', function(e){
-      $(this).closest('.galleryField__item').remove()
+      $(this).closest('.galleryField__item').remove();
       keepState(app.content.reload);
     })
 
     element.on('click', '.galleryField__addBtn', function(e){
       e.preventDefault()
-      var selectListContent = element.find('.galleryField__selectTemplate').html()
-      $('.galleryField__items--select', element).html(selectListContent)
+      var selectListContent = element.find('.galleryField__selectTemplate').html();
+      $('.galleryField__items--select', element).html(selectListContent);
       $('.galleryField__items--select', element).removeClass('hidden');
       $('.galleryField__items--sort', element).addClass('hidden');
     })
 
     element.on('click', '.galleryField__saveSelectionBtn', function(e){
-      e.preventDefault()
-      var sortedItems = $('.galleryField__items--sort .galleryField__item', element)
-      var selectedItems = $('.galleryField__items--select .galleryField__item--selected', element)
+      e.preventDefault();
+      var sortedItems = $('.galleryField__items--sort .galleryField__item', element);
+      var selectedItems = $('.galleryField__items--select .galleryField__item--selected', element);
       var oldSelected = sortedItems.map(function(){
-        return $(this).data('image-name')
+        return $(this).data('image-name');
       }).toArray()
       var newSelected = selectedItems.map(function(){
-        return $(this).data('image-name')
+        return $(this).data('image-name');
       }).toArray()
       oldSelected.forEach(function(item, index){
         if ($.inArray(item, newSelected) == -1){
@@ -39,13 +39,13 @@
       newSelected.forEach(function(item, index){
         if ($.inArray(item, oldSelected) == -1){
           var inputElement = $('.galleryField__inputTemplate', element).html()
-          inputElement = $(inputElement)
-          inputElement.val(item)
-          $('.galleryField__items--sort').append(inputElement)
+          inputElement = $(inputElement);
+          inputElement.val(item);
+          $('.galleryField__items--sort').append(inputElement);
         }
       })
       keepState(app.content.reload);
-    })    
+    })
 
     element.on('click', '.galleryField__items--select .galleryField__item', function(e){
       $(this).toggleClass('galleryField__item--selected')
@@ -78,9 +78,30 @@
     });
 
     var keepState = function(callback){
-      $.post(keepUrl+'?'+mainForm.serialize(), function( data ) {
-        callback()
-      });
+      if(typeof keepUrl === 'undefined') {
+        // Compatibility with KirbyBuilder Plugin (https://github.com/TimOetting/kirby-builder)
+        var kirbyBuilder = mainForm.closest('.builder-entry');
+
+        if(kirbyBuilder) {
+          var fieldID = mainForm.closest('.builder-entry').find('.builder-entry-quickform-container').data('quickform-container');
+          var data = mainForm.serialize().split(fieldID + '-').join('');
+          var url = mainForm.attr('action');
+          var urlParamSeparator = (url.indexOf('?') > -1) ? '&' : '?'
+
+          $.ajax({
+            type: "POST",
+            url: url + urlParamSeparator + data,
+            success: function(){
+              // don't relead as always, because we are now witihin the builder panel
+            }
+          });
+        }
+      } else {
+        // default behaviour
+        $.post(keepUrl+'?'+mainForm.serialize(), function( data ) {
+          callback();
+        });
+      }
     }
 
     var showSelectList = function(e){
@@ -90,7 +111,6 @@
   };
 
   $.fn.gallery = function() {
-
     return this.each(function() {
 
       if($(this).data('gallery')) {


### PR DESCRIPTION
I added compatibility with [kirby-builder](https://github.com/TimOetting/kirby-builder). Because kiry-builder is providing a own form per section, the kirby-gallery could not handle this specific case. Instead it will now post the chances via ajax, using the provided url from the builder form.

See bug report #9 
