### PR TITLE
change name for CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kirby-gallery",
+  "name": "gallery",
   "description": "A gallery field for Kirby CMS",
   "author": "Tim Ötting <tim@whateveryouremailaddresis.com>",
   "license": "MIT",


### PR DESCRIPTION
You have to omit the 'kirby-' in order to install the field with the Kirby CLI (without renaming it afterwards)